### PR TITLE
websocket: add requestHeader parameter to Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # janus-go
 
 
-only support websocekt transport
+only support websocket transport
+
+Update 12/22/2020
+
+Notedit, the original creator is busy with other things, and has given me maintainer/collaborator status on this project.
+
+I am trying to meet a number of technical goals so I can use this package in a reliable way
+in production environments.
+
+I have decided to currently do most of this work here:
+[https://github.com/cameronelliott/janus-go](https://github.com/cameronelliott/janus-go)
+
+Please see if it suits your needs, and feel free to file PRs, issues and suggests there.
+
+Thanks,
+Cameron
+
+

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ in production environments.
 I have decided to currently do most of this work here:
 [https://github.com/cameronelliott/janus-go](https://github.com/cameronelliott/janus-go)
 
-Please see if it suits your needs, and feel free to file PRs, issues and suggests there.
+Please see if it suits your needs, and feel free to file PRs, issues and suggestions there.
 
 Thanks,
 Cameron

--- a/README.md
+++ b/README.md
@@ -3,19 +3,18 @@
 
 only support websocket transport
 
-Update 12/22/2020
+Update 1/14/2020
 
-Notedit, the original creator is busy with other things, and has given me maintainer/collaborator status on this project.
+Notedit, the original creator is busy with other things, and has handed over the maintainer role on this project.
 
-I am trying to meet a number of technical goals so I can use this package in a reliable way
-in production environments.
 
-I have decided to currently do most of this work here:
-[https://github.com/cameronelliott/janus-go](https://github.com/cameronelliott/janus-go)
+You can find a fork by [@nustiueudinastea](https://github.com/nustiueudinastea)
+Here:
+[https://github.com/nustiueudinastea/janus-go](https://github.com/nustiueudinastea/janus-go)
 
 Please see if it suits your needs, and feel free to file PRs, issues and suggestions there.
 
 Thanks,
-Cameron
+Cameron and Alex
 
 

--- a/janus.go
+++ b/janus.go
@@ -34,7 +34,7 @@ type Gateway struct {
 	Sessions map[uint64]*Session
 
 	// Access to the Sessions map should be synchronized with the Gateway.Lock()
-	// and Gateway.Unlock() methods provided by the embeded sync.Mutex.
+	// and Gateway.Unlock() methods provided by the embedded sync.Mutex.
 	sync.Mutex
 
 	conn             *websocket.Conn
@@ -49,7 +49,7 @@ func generateTransactionId() xid.ID {
 	return xid.New()
 }
 
-// Connect initiates a webscoket connection with the Janus Gateway
+// Connect initiates a websocket connection with the Janus Gateway
 func Connect(wsURL string, requestHeader http.Header) (*Gateway, error) {
 	websocket.DefaultDialer.Subprotocols = []string{"janus-protocol"}
 

--- a/janus.go
+++ b/janus.go
@@ -8,12 +8,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/rs/xid"
 )
 
 var debug = false
@@ -38,12 +37,15 @@ type Gateway struct {
 	sync.Mutex
 
 	conn             *websocket.Conn
-	nextTransaction  uint64
-	transactions     map[uint64]chan interface{}
-	transactionsUsed map[uint64]bool
+	transactions     map[xid.ID]chan interface{}
+	transactionsUsed map[xid.ID]bool
 	errors           chan error
 	sendChan         chan []byte
 	writeMu          sync.Mutex
+}
+
+func generateTransactionId() xid.ID {
+	return xid.New()
 }
 
 // Connect initiates a webscoket connection with the Janus Gateway
@@ -58,8 +60,8 @@ func Connect(wsURL string) (*Gateway, error) {
 
 	gateway := new(Gateway)
 	gateway.conn = conn
-	gateway.transactions = make(map[uint64]chan interface{})
-	gateway.transactionsUsed = make(map[uint64]bool)
+	gateway.transactions = make(map[xid.ID]chan interface{})
+	gateway.transactionsUsed = make(map[xid.ID]bool)
 	gateway.Sessions = make(map[uint64]*Session)
 	gateway.sendChan = make(chan []byte, 100)
 	gateway.errors = make(chan error)
@@ -80,12 +82,12 @@ func (gateway *Gateway) GetErrChan() chan error {
 }
 
 func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interface{}) {
-	id := atomic.AddUint64(&gateway.nextTransaction, 1)
+	guid := generateTransactionId()
 
-	msg["transaction"] = strconv.FormatUint(id, 10)
+	msg["transaction"] = guid.String()
 	gateway.Lock()
-	gateway.transactions[id] = transaction
-	gateway.transactionsUsed[id] = false
+	gateway.transactions[guid] = transaction
+	gateway.transactionsUsed[guid] = false
 	gateway.Unlock()
 
 	data, err := json.Marshal(msg)
@@ -191,7 +193,7 @@ func (gateway *Gateway) recv() {
 
 		var transactionUsed bool
 		if base.ID != "" {
-			id, _ := strconv.ParseUint(base.ID, 10, 64)
+			id, _ := xid.FromString(base.ID)
 			gateway.Lock()
 			transactionUsed = gateway.transactionsUsed[id]
 			gateway.Unlock()
@@ -226,7 +228,7 @@ func (gateway *Gateway) recv() {
 				go passMsg(handle.Events, msg)
 			}
 		} else {
-			id, _ := strconv.ParseUint(base.ID, 10, 64)
+			id, _ := xid.FromString(base.ID)
 			// Lookup Transaction
 			gateway.Lock()
 			transaction := gateway.transactions[id]

--- a/janus.go
+++ b/janus.go
@@ -92,7 +92,7 @@ func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interf
 
 	data, err := json.Marshal(msg)
 	if err != nil {
-		fmt.Printf("json.Marshal: %s\n", err)
+		log.Printf("json.Marshal: %s\n", err)
 		return
 	}
 
@@ -112,7 +112,7 @@ func (gateway *Gateway) send(msg map[string]interface{}, transaction chan interf
 		select {
 		case gateway.errors <- err:
 		default:
-			fmt.Printf("conn.Write: %s\n", err)
+			log.Printf("conn.Write: %s\n", err)
 		}
 
 		return
@@ -160,14 +160,14 @@ func (gateway *Gateway) recv() {
 			select {
 			case gateway.errors <- err:
 			default:
-				fmt.Printf("conn.Read: %s\n", err)
+				log.Printf("conn.Read: %s\n", err)
 			}
 
 			return
 		}
 
 		if err := json.Unmarshal(data, &base); err != nil {
-			fmt.Printf("json.Unmarshal: %s\n", err)
+			log.Printf("json.Unmarshal: %s\n", err)
 			continue
 		}
 
@@ -181,13 +181,13 @@ func (gateway *Gateway) recv() {
 
 		typeFunc, ok := msgtypes[base.Type]
 		if !ok {
-			fmt.Printf("Unknown message type received!\n")
+			log.Printf("Unknown message type received!\n")
 			continue
 		}
 
 		msg := typeFunc()
 		if err := json.Unmarshal(data, &msg); err != nil {
-			fmt.Printf("json.Unmarshal: %s\n", err)
+			log.Printf("json.Unmarshal: %s\n", err)
 			continue // Decode error
 		}
 
@@ -211,7 +211,7 @@ func (gateway *Gateway) recv() {
 				session := gateway.Sessions[base.Session]
 				gateway.Unlock()
 				if session == nil {
-					fmt.Printf("Unable to deliver message. Session gone?\n")
+					log.Printf("Unable to deliver message. Session gone?\n")
 					continue
 				}
 
@@ -220,7 +220,7 @@ func (gateway *Gateway) recv() {
 				handle := session.Handles[base.Handle]
 				session.Unlock()
 				if handle == nil {
-					fmt.Printf("Unable to deliver message. Handle gone?\n")
+					log.Printf("Unable to deliver message. Handle gone?\n")
 					continue
 				}
 

--- a/janus.go
+++ b/janus.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"log"
 	"os"
 	"sync"
@@ -49,10 +50,10 @@ func generateTransactionId() xid.ID {
 }
 
 // Connect initiates a webscoket connection with the Janus Gateway
-func Connect(wsURL string) (*Gateway, error) {
+func Connect(wsURL string, requestHeader http.Header) (*Gateway, error) {
 	websocket.DefaultDialer.Subprotocols = []string{"janus-protocol"}
 
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, requestHeader)
 
 	if err != nil {
 		return nil, err

--- a/janus_test.go
+++ b/janus_test.go
@@ -1,12 +1,14 @@
 package janus
 
 import (
+	"net/http"
 	"testing"
 )
 
 func Test_Connect(t *testing.T) {
 
-	client, err := Connect("ws://39.106.248.166:8188/")
+	reqHeader := http.Header{"User-Agent": []string{"janus-test"}}
+	client, err := Connect("ws://39.106.248.166:8188/", reqHeader)
 	if err != nil {
 		t.Fail()
 		return


### PR DESCRIPTION
This is an API breaking change but the old behavior can be used if `nil` is given as the new argument to Connect.

Checked with wireshark:

![image](https://user-images.githubusercontent.com/66862/181025852-322bf0cb-8a06-4b4b-a683-575dc9952618.png)
